### PR TITLE
Offiicial Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Base image for building purposes
+FROM golang:1.14-alpine as builder
+
+RUN apk --no-cache add alsa-lib-dev git alpine-sdk
+
+WORKDIR /jellycli
+
+ARG JELLYCLI_BRANCH=master
+
+# use caching layers as needed
+
+RUN git clone -b ${JELLYCLI_BRANCH} --single-branch --depth 1 https://github.com/tryffel/jellycli ./
+
+RUN go mod download
+
+RUN go build . && ./jellycli -help
+
+
+# Alpine runtime
+FROM alpine:3.10
+
+RUN apk --no-cache add alsa-lib-dev
+
+COPY --from=builder /jellycli/jellycli /usr/local/bin
+
+# This is kind of a hack. Creates the default config dir and fakes machine-id
+# since alpine has no systemd.
+RUN mkdir /root/.config/ \
+&& echo "Fake-MachineId-ForNonSystemD" > /etc/machine-id
+
+ENTRYPOINT [ "jellycli" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,8 @@ RUN go build . && ./jellycli -help
 # Alpine runtime
 FROM alpine:3.10
 
-RUN apk --no-cache add alsa-lib-dev
-
+RUN apk --no-cache add alsa-lib-dev dbus-x11
 COPY --from=builder /jellycli/jellycli /usr/local/bin
 
-# This is kind of a hack. Creates the default config dir and fakes machine-id
-# since alpine has no systemd.
-RUN mkdir /root/.config/ \
-&& echo "Fake-MachineId-ForNonSystemD" > /etc/machine-id
-
+RUN mkdir /root/.config/
 ENTRYPOINT [ "jellycli" ]


### PR DESCRIPTION
Hi @tryffel, this is a working sample.
The image is based on Alpine linux, and the final build size is ~26MB. The repository is cloned on build time, so you can tag different versions .i.e 
```bash
docker build -t jellycli:0.2.0 .
```

You can also build a different branch/tag using the `JELLYCLI_BRANCH` build argument.
```bash
docker build -t jellycli:0.2.0 --build-arg JELLYCLI_BRANCH=develop  .
```

For the usage, you need to map the `/dev/snd` device, and would probably use a volume to persist the configuration file. You can also provide any `jellycli` arguments after the image name as with any docker image.

```bash
docker build run -it --rm --device /dev/snd -v ~/jellyfin:/root/.config jellycli:0.2.0
```

I think it would be great if `jellycli` would support environment variables as well for the Jellyfin server URL username/password and such. Perhaps you can integrate viper which is quite known in the go ecosystem?
