### PR TITLE
Fully qualify Docker image names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image for building purposes
-FROM golang:1.15.5-alpine3.12 as builder
+FROM docker.io/golang:1.15.5-alpine3.12 as builder
 
 RUN apk --no-cache add alsa-lib-dev git alpine-sdk
 
@@ -17,7 +17,7 @@ RUN go build . && ./jellycli --help
 
 
 # Alpine runtime
-FROM alpine:3.12
+FROM docker.io/alpine:3.12
 
 RUN apk --no-cache add alsa-lib-dev dbus-x11 alsa-utils
 COPY --from=builder /jellycli/jellycli /usr/local/bin


### PR DESCRIPTION
Fixes #29 

The Dockerfile can be built with Podman without issue.

```sh
podman build -t jellycli:latest .
```